### PR TITLE
Added an option to import lots without costs

### DIFF
--- a/src/assets/i18n/locales/be.json
+++ b/src/assets/i18n/locales/be.json
@@ -143,6 +143,7 @@
     "spicyFinal": "Чырвоны фінал (маю наўвазе перац, ніякіх зорак)",
     "connectTwitchForMoreEmotes": "Падключыце Twitch, каб абраць больш выяваў у коле.",
     "addLotsToAuc": "Захаваць латы ў аўк",
+    "lotsWithoutCosts": "Лоты без кошту",
     "format": {
       "normal": "Звычайнае",
       "dropout": "Выбываньне",

--- a/src/assets/i18n/locales/en.json
+++ b/src/assets/i18n/locales/en.json
@@ -150,6 +150,7 @@
     "spicyFinal": "Spicy Final",
     "connectTwitchForMoreEmotes": "Connect Twitch to choose more images on the wheel",
     "addLotsToAuc": "Save lots in auction",
+    "lotsWithoutCosts": "Lots without costs",
     "format": {
       "normal": "Normal",
       "dropout": "Dropout",

--- a/src/assets/i18n/locales/ru.json
+++ b/src/assets/i18n/locales/ru.json
@@ -157,6 +157,7 @@
     "spicyFinal": "Финал с перчинкой",
     "connectTwitchForMoreEmotes": "Подключите Twitch, чтобы выбрать больше изображений в колесе",
     "addLotsToAuc": "Сохранить лоты в аук",
+    "lotsWithoutCosts": "Лоты без стоимости",
     "format": {
       "normal": "Обычное",
       "dropout": "Выбывание",

--- a/src/assets/i18n/locales/uk.json
+++ b/src/assets/i18n/locales/uk.json
@@ -150,6 +150,7 @@
     "spicyFinal": "Spicy Final",
     "connectTwitchForMoreEmotes": "Connect Twitch to choose more images on the wheel",
     "addLotsToAuc": "Save lots in auction",
+    "lotsWithoutCosts": "Lots without costs",
     "format": {
       "normal": "Normal",
       "dropout": "Dropout",

--- a/src/components/Form/SlotsPresetInput/SlotsPresetInput.scss
+++ b/src/components/Form/SlotsPresetInput/SlotsPresetInput.scss
@@ -14,7 +14,7 @@
   }
 }
 
-.save-slots-checkbox {
+.image-input-wrapper .save-slots-checkbox {
   align-items: center !important;
   margin-top: 10px;
 }

--- a/src/components/Form/SlotsPresetInput/SlotsPresetInput.tsx
+++ b/src/components/Form/SlotsPresetInput/SlotsPresetInput.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode, useState } from 'react';
-import { Button, Checkbox, Dialog, DialogContent, DialogTitle, FormControlLabel } from '@mui/material';
+import { Button, Checkbox, Dialog, DialogContent, DialogTitle, FormControlLabel, FormGroup } from '@mui/material';
 import { DropzoneArea } from 'react-mui-dropzone';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +20,7 @@ const SlotsPresetInput: FC<SlotsPresetInput> = ({ onChange, buttonTitle, buttonC
   const { t } = useTranslation();
   const [isInputOpened, setIsInputOpened] = useState<boolean>(false);
   const [saveSlots, setSaveSlots] = useState<boolean>(false);
+  const [noCosts, setNoCosts] = useState<boolean>(false);
   const toggleDialog = (): void => {
     setIsInputOpened((prevOpened) => !prevOpened);
   };
@@ -29,7 +30,7 @@ const SlotsPresetInput: FC<SlotsPresetInput> = ({ onChange, buttonTitle, buttonC
 
     reader.onloadend = (): void => {
       if (typeof reader.result === 'string') {
-        onChange(parseSlotsPreset(reader.result), saveSlots);
+        onChange(parseSlotsPreset(reader.result, noCosts), saveSlots);
         setIsInputOpened(false);
       }
     };
@@ -38,6 +39,10 @@ const SlotsPresetInput: FC<SlotsPresetInput> = ({ onChange, buttonTitle, buttonC
 
   const handleSaveSlotsChange = (event: any): void => {
     setSaveSlots(event.target.checked);
+  };
+
+  const handleNoCostsChange = (event: any): void => {
+    setNoCosts(event.target.checked);
   };
 
   return (
@@ -51,11 +56,18 @@ const SlotsPresetInput: FC<SlotsPresetInput> = ({ onChange, buttonTitle, buttonC
             onDrop={handleFileUpload}
             filesLimit={1}
           />
-          <FormControlLabel
-            className='save-slots-checkbox'
-            control={<Checkbox checked={saveSlots} onChange={handleSaveSlotsChange} color='primary' />}
-            label={t('wheel.addLotsToAuc')}
-          />
+          <FormGroup row={true}>
+            <FormControlLabel
+              className='save-slots-checkbox'
+              control={<Checkbox checked={saveSlots} onChange={handleSaveSlotsChange} color='primary' />}
+              label={t('wheel.addLotsToAuc')}
+            />
+            <FormControlLabel
+              className='save-slots-checkbox'
+              control={<Checkbox checked={noCosts} onChange={handleNoCostsChange} color='primary' />}
+              label={t('wheel.lotsWithoutCosts')}
+            />
+          </FormGroup>
           {hint && <div className='slots-preset-input-hint'>{hint}</div>}
         </DialogContent>
       </Dialog>

--- a/src/utils/slots.utils.ts
+++ b/src/utils/slots.utils.ts
@@ -16,14 +16,17 @@ export const parseWheelPreset = (text: string): WheelItem[] => {
   return text.split('\n').map<WheelItem>((value, id) => ({ id: id.toString(), name: value, color: getWheelColor() }));
 };
 
-export const parseSlotsPreset = (text: string): Slot[] => {
+export const parseSlotsPreset = (text: string, noAmounts: boolean): Slot[] => {
   const items = text.split('\n');
 
-  return items.map<Slot>((item, fastId) => {
-    const [name, amount = 1] = item.split(',');
+  return noAmounts
+    ? items.map<Slot>((name, fastId) =>
+      ({ name, amount: 1, id: Math.random().toString(), fastId, extra: null, investors: [] }))
+    : items.map<Slot>((item, fastId) => {
+      const [name, amount = 1] = item.split(',');
 
-    return { name, amount: Number(amount), id: Math.random().toString(), fastId, extra: null, investors: [] };
-  });
+      return { name, amount: Number(amount), id: Math.random().toString(), fastId, extra: null, investors: [] };
+    });
 };
 
 export const slotToWheel = ({ id, name, amount }: Slot): WheelItem => ({


### PR DESCRIPTION
In some cases, the wheel is just used to randomize a plain list of items regardless of any auction, but the site treats each line as a csv string with a numeric value.

https://github.com/Pointauc/pointauc_frontend/blob/9745464cc13b5a72eedb313a65f0d428c5a5ed14/src/utils/slots.utils.ts#L23

This causes problems when the imported text file contains commas.

This PR implements an additional option to disable such parsing while importing lots.

![Lots without costs](https://github.com/Pointauc/pointauc_frontend/assets/3943889/0773ce0a-7809-4c17-b12d-3a61323bfa80)
