### PR TITLE
fix: use mantine input prop to style invalide state

### DIFF
--- a/src/pages/auction/Slot/SlotComponent.tsx
+++ b/src/pages/auction/Slot/SlotComponent.tsx
@@ -116,7 +116,7 @@ const SlotComponent: FC<SlotComponentProps> = ({ slot }) => {
 
   const extraLength = Number(currentExtra?.toString().length);
   const extraFieldWidth = `${extraLength > 4 ? 2 + extraLength * 1.1 : 7}ch`;
-
+  const showError =  amount === null ? false : amount  < 1 ? true : false
   return (
     <>
       <TextInput
@@ -140,8 +140,8 @@ const SlotComponent: FC<SlotComponentProps> = ({ slot }) => {
         placeholder={t('common.currencySign')}
         ref={amountInput}
         onKeyPress={createNewSlotOnEnter}
+        error={showError}
         type='number'
-        min='0'
       />
       <button className='slot-icon-button slot-add-extra' onClick={handleAddExtra} title={t('lot.addAmount')}>
         <AddIcon />


### PR DESCRIPTION
min prop doesn't do anything without style :invalid using mantine prop instead 
also raises min to 1 because 0 value slots are not included in a wheel  
fixes #38 
before:
<img width="1128" height="230" alt="before" src="https://github.com/user-attachments/assets/eb1448f8-bc43-4f87-981f-0d108faa9688" />
after:
<img width="1133" height="231" alt="after" src="https://github.com/user-attachments/assets/93f42c45-1e5a-4291-86b1-36ab10ba0386" />
